### PR TITLE
sync firecrawl skills (509dd9c)

### DIFF
--- a/skills/firecrawl-agent/SKILL.md
+++ b/skills/firecrawl-agent/SKILL.md
@@ -55,3 +55,4 @@ firecrawl agent "<job-id>" --cancel
 - [firecrawl-scrape](../firecrawl-scrape/SKILL.md) — simpler single-page extraction
 - [firecrawl-interact](../firecrawl-interact/SKILL.md) — scrape + interact for manual page interaction (more control)
 - [firecrawl-crawl](../firecrawl-crawl/SKILL.md) — bulk extraction without AI
+- [firecrawl-build-scrape](https://github.com/firecrawl/skills/tree/main/skills/build/firecrawl-build-scrape) — building structured extraction into an app instead of running it here

--- a/skills/firecrawl-crawl/SKILL.md
+++ b/skills/firecrawl-crawl/SKILL.md
@@ -41,3 +41,4 @@ Run `firecrawl crawl --help` for the full option list.
 - [firecrawl-scrape](../firecrawl-scrape/SKILL.md) — scrape individual pages
 - [firecrawl-map](../firecrawl-map/SKILL.md) — discover URLs before deciding to crawl
 - [firecrawl-download](../firecrawl-download/SKILL.md) — download site to local files (uses map + scrape)
+- [firecrawl-build-scrape](https://github.com/firecrawl/skills/tree/main/skills/build/firecrawl-build-scrape) — building bulk extraction into an app instead of running it here

--- a/skills/firecrawl-developer-index/SKILL.md
+++ b/skills/firecrawl-developer-index/SKILL.md
@@ -57,3 +57,7 @@ Only the HTTP surface takes these. On `GET`, pass `types=issue,pull_request` or 
 - **A merge supersedes a report.** When an issue and a pull request disagree, the merged pull request is the current behaviour. Say which one you read.
 - **Scope last, not first.** Search the whole index, then narrow with `types`, `repos`, or `sources` once you know what the hits look like. Scoping first hides the result that would have told you where to look.
 - **Go to the web when the index has nothing to say.** Trade-offs, ecosystem opinion, and anything about an unindexed project are web questions. Don't force them through the index, and don't dress a general web page up as a primary source.
+
+## See also
+
+- [firecrawl-build-search](https://github.com/firecrawl/skills/tree/main/skills/build/firecrawl-build-search) — building the developer index into an app instead of querying it here

--- a/skills/firecrawl-download/SKILL.md
+++ b/skills/firecrawl-download/SKILL.md
@@ -41,3 +41,4 @@ Run `firecrawl x download --help` for the full option list, including which scra
 - [firecrawl-map](../firecrawl-map/SKILL.md) — just discover URLs without downloading
 - [firecrawl-scrape](../firecrawl-scrape/SKILL.md) — scrape individual pages
 - [firecrawl-crawl](../firecrawl-crawl/SKILL.md) — bulk extract as JSON (not local files)
+- [firecrawl-build-scrape](https://github.com/firecrawl/skills/tree/main/skills/build/firecrawl-build-scrape) — building bulk extraction into an app instead of running it here

--- a/skills/firecrawl-interact/SKILL.md
+++ b/skills/firecrawl-interact/SKILL.md
@@ -69,3 +69,4 @@ firecrawl scrape "https://app.example.com" --profile my-app --no-save-changes
 - [firecrawl-scrape](../firecrawl-scrape/SKILL.md) — try scrape first, escalate to interact only when needed
 - [firecrawl-search](../firecrawl-search/SKILL.md) — use `search` for web searches
 - [firecrawl-agent](../firecrawl-agent/SKILL.md) — AI-powered extraction (less manual control)
+- [firecrawl-build-interact](https://github.com/firecrawl/skills/tree/main/skills/build/firecrawl-build-interact) — building interact into an app instead of running it here

--- a/skills/firecrawl-map/SKILL.md
+++ b/skills/firecrawl-map/SKILL.md
@@ -37,3 +37,4 @@ Run `firecrawl map --help` for the full option list (sitemap handling, subdomain
 - [firecrawl-scrape](../firecrawl-scrape/SKILL.md) — scrape the URLs you discover
 - [firecrawl-crawl](../firecrawl-crawl/SKILL.md) — bulk extract instead of map + scrape
 - [firecrawl-download](../firecrawl-download/SKILL.md) — download entire site (uses map internally)
+- [firecrawl-build-search](https://github.com/firecrawl/skills/tree/main/skills/build/firecrawl-build-search) — building URL discovery into an app instead of running it here

--- a/skills/firecrawl-monitor/SKILL.md
+++ b/skills/firecrawl-monitor/SKILL.md
@@ -78,3 +78,4 @@ Read [goals.md](goals.md) when writing or refining `--goal` (and `--queries` for
 - [firecrawl-scrape](../firecrawl-scrape/SKILL.md) — one-off scrape; escalate to `monitor` when checks become recurring
 - [firecrawl-crawl](../firecrawl-crawl/SKILL.md) — one-off crawl; pair with `--crawl-url` here for recurring crawl diffs
 - [firecrawl](../firecrawl/SKILL.md) — top-level workflow guide
+- [firecrawl-build-scrape](https://github.com/firecrawl/skills/tree/main/skills/build/firecrawl-build-scrape) — building recurring checks into an app instead of running it here

--- a/skills/firecrawl-parse/SKILL.md
+++ b/skills/firecrawl-parse/SKILL.md
@@ -46,3 +46,4 @@ Run `firecrawl parse --help` for the full option list.
 ## See also
 
 - [firecrawl-scrape](../firecrawl-scrape/SKILL.md) — same idea for URLs
+- [firecrawl-build-scrape](https://github.com/firecrawl/skills/tree/main/skills/build/firecrawl-build-scrape) — building document extraction into an app instead of running it here

--- a/skills/firecrawl-research-index/SKILL.md
+++ b/skills/firecrawl-research-index/SKILL.md
@@ -67,3 +67,7 @@ There is **no fixed recipe**. Read the query, decide what kind it is, and choose
 - **Follow the literature, and keep what you find.** The seminal source, the competing methods, the close neighbors are usually a hop away — use `related_papers`, and _include_ them, not just the first hit. Stopping at one good result is the most common way to leave the reader with half an answer.
 - **Verify to exclude, not to gatekeep.** Use `read_paper` to rule a paper _out_ when a hard constraint clearly fails (wrong org/author, doesn't actually report the score). When a paper is plausibly relevant, lean toward keeping it rather than demanding proof.
 - **Only drop the clearly off-topic.** Don't pad with papers you're confident are unrelated — but that's a high bar; most plausibly-relevant work should make the cut.
+
+## See also
+
+- [firecrawl-build-search](https://github.com/firecrawl/skills/tree/main/skills/build/firecrawl-build-search) — building the paper index into an app instead of querying it here

--- a/skills/firecrawl-scrape/SKILL.md
+++ b/skills/firecrawl-scrape/SKILL.md
@@ -51,3 +51,4 @@ Run `firecrawl scrape --help` for the full option list.
 - [firecrawl-search](../firecrawl-search/SKILL.md) — find pages when you don't have a URL
 - [firecrawl-interact](../firecrawl-interact/SKILL.md) — when scrape can't get the content, use `interact` to click, fill forms, etc.
 - [firecrawl-download](../firecrawl-download/SKILL.md) — bulk download an entire site to local files
+- [firecrawl-build-scrape](https://github.com/firecrawl/skills/tree/main/skills/build/firecrawl-build-scrape) — building scrape into an app instead of running it here

--- a/skills/firecrawl-search/SKILL.md
+++ b/skills/firecrawl-search/SKILL.md
@@ -87,3 +87,4 @@ fi
 - [firecrawl-crawl](../firecrawl-crawl/SKILL.md) — bulk extract from a site
 - [firecrawl-developer-index](../firecrawl-developer-index/SKILL.md) — issues, merged PRs, READMEs, and docs
 - [firecrawl-research-index](../firecrawl-research-index/SKILL.md) — published papers, not `search --categories research`
+- [firecrawl-build-search](https://github.com/firecrawl/skills/tree/main/skills/build/firecrawl-build-search) — building search into an app instead of running it here

--- a/skills/firecrawl/SKILL.md
+++ b/skills/firecrawl/SKILL.md
@@ -76,7 +76,7 @@ For detailed command reference, run `firecrawl <command> --help`.
 - **Detecting content changes on a website and getting notified by webhook or email (pricing, jobs, posts, docs, status pages, anything ongoing)** -> [firecrawl-monitor](../firecrawl-monitor/SKILL.md)
 - **Install, auth, or setup problems** -> [rules/install.md](rules/install.md)
 - **Output handling and safe file-reading patterns** -> [rules/security.md](rules/security.md)
-- **Integrating Firecrawl into an app, adding `FIRECRAWL_API_KEY` to `.env`, or choosing endpoint usage in product code** -> use the `firecrawl-build` skills (already installed alongside this CLI skill)
+- **Integrating Firecrawl into an app, adding `FIRECRAWL_API_KEY` to `.env`, or choosing endpoint usage in product code** -> the [firecrawl-build skills](https://github.com/firecrawl/skills/tree/main/skills/build) (`firecrawl-build-onboarding`, `-scrape`, `-search`, `-interact`). They live in a separate repo; install with `firecrawl setup build`.
 - **Producing Firecrawl-powered deliverables such as research briefs, SEO audits, QA reports, lead lists, knowledge bases, or design-system extraction** -> use the `firecrawl-workflows` skills (already installed alongside this CLI skill). These skills infer from context first and ask only short blocking questions when needed.
 
 ## Output & Organization


### PR DESCRIPTION
Automated sync of `skills/` from [firecrawl/cli@509dd9c](https://github.com/firecrawl/cli/commit/509dd9c51789bc40e1e49bf17a97c88f70e3c0f9) into `skills/`.